### PR TITLE
Expose a new function to attempt to load the Outlook MAPI subsystem binary

### DIFF
--- a/crates/mapi-sys/src/lib.rs
+++ b/crates/mapi-sys/src/lib.rs
@@ -22,6 +22,9 @@ fn get_mapi_module() -> HMODULE {
     })
 }
 
+#[cfg(feature = "olmapi32")]
+pub use load_mapi::ensure_olmapi32;
+
 #[macro_use]
 extern crate outlook_mapi_stub;
 


### PR DESCRIPTION
Exposes a new function from the outlook-mapi-sys crate to attempt to find + load the Outlook MAPI subsystem DLL: olmapi32.dll